### PR TITLE
Added the ability to specify dark and light colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,22 @@ Pass the background color of element to get the right color contrast for the tex
 <div ng-show="labels" class="labels">
   <a ng-repeat="label in labels" href="#" target="_blank">
     <span class="label" color-contrast="{{label.color}}">{{label.name}}</span>
-  </a> 
+  </a>
+</div>
+```
+
+By default, light and dark colors are specified as `#ffffff` and `#000000` respectively. You can also pass your own color values as HEX colors for custom control over the light and dark colors that are applied.
+
+```javascript
+...
+$scope.myDarkColor = '#444';
+...
+```
+```html
+<div ng-show="labels" class="labels">
+  <a ng-repeat="label in labels" href="#" target="_blank">
+    <span class="label" color-contrast="{{label.color}}" light-color="'#eee'" dark-color="myDarkColor">{{label.name}}</span>
+  </a>
 </div>
 ```
 

--- a/src/color-contrast.js
+++ b/src/color-contrast.js
@@ -27,16 +27,16 @@ angular.module('colorContrast', [])
       },
       link: function postLink(scope, element, attrs) {
         if(!attrs.darkColor){
-          scope.darkColor = '000000';
+          scope.darkColor = '#000000';
         }
         if(!attrs.lightColor){
-          scope.lightColor = 'ffffff';
+          scope.lightColor = '#ffffff';
         }
         attrs.$observe('colorContrast', function(color) {
           if (color) {
             color = stripNumberSign(color);
             element.css("background-color", "#" + color);
-            element.css("color", "#" + getContrastYIQ(color, scope.darkColor, scope.lightColor));
+            element.css("color", getContrastYIQ(color, scope.darkColor, scope.lightColor));
           }
         });
       }

--- a/src/color-contrast.js
+++ b/src/color-contrast.js
@@ -26,6 +26,12 @@ angular.module('colorContrast', [])
         lightColor: '=?'
       },
       link: function postLink(scope, element, attrs) {
+        if(!attrs.darkColor){
+          scope.darkColor = '000000';
+        }
+        if(!attrs.lightColor){
+          scope.lightColor = '000000';
+        }
         attrs.$observe('colorContrast', function(color) {
           if (color) {
             color = stripNumberSign(color);

--- a/src/color-contrast.js
+++ b/src/color-contrast.js
@@ -36,10 +36,10 @@ angular.module('colorContrast', [])
           if (color) {
             color = stripNumberSign(color);
             element.css("background-color", "#" + color);
-            element.css("color", "#" + getContrastYIQ(color));
+            element.css("color", "#" + getContrastYIQ(color, scope.darkColor, scope.lightColor));
           }
         });
       }
     };
-    
+
   });

--- a/src/color-contrast.js
+++ b/src/color-contrast.js
@@ -30,7 +30,7 @@ angular.module('colorContrast', [])
           scope.darkColor = '000000';
         }
         if(!attrs.lightColor){
-          scope.lightColor = '000000';
+          scope.lightColor = 'ffffff';
         }
         attrs.$observe('colorContrast', function(color) {
           if (color) {

--- a/src/color-contrast.js
+++ b/src/color-contrast.js
@@ -2,11 +2,7 @@
 
 angular.module('colorContrast', [])
   .directive('colorContrast', function () {
-    
-    var DARK = '000000';
-    
-    var LIGHT = 'FFFFFF';
-    
+
     // 24 WAYS - http://24ways.org/2010/calculating-color-contrast/
     function getContrastYIQ(hexcolor){
     	var r = parseInt(hexcolor.substr(0,2),16);

--- a/src/color-contrast.js
+++ b/src/color-contrast.js
@@ -4,12 +4,12 @@ angular.module('colorContrast', [])
   .directive('colorContrast', function () {
 
     // 24 WAYS - http://24ways.org/2010/calculating-color-contrast/
-    function getContrastYIQ(hexcolor){
+    function getContrastYIQ(hexcolor, darkColor, lightColor){
     	var r = parseInt(hexcolor.substr(0,2),16);
     	var g = parseInt(hexcolor.substr(2,2),16);
     	var b = parseInt(hexcolor.substr(4,2),16);
     	var yiq = ((r*299)+(g*587)+(b*114))/1000;
-    	return (yiq >= 128) ? DARK : LIGHT;
+    	return (yiq >= 128) ? darkColor : lightColor;
     };
 
     function stripNumberSign(color){

--- a/src/color-contrast.js
+++ b/src/color-contrast.js
@@ -18,9 +18,13 @@ angular.module('colorContrast', [])
         }
         return color;
     };
-    
+
     return {
       restrict: 'A',
+      scope: {
+        darkColor: '=?',
+        lightColor: '=?'
+      },
       link: function postLink(scope, element, attrs) {
         attrs.$observe('colorContrast', function(color) {
           if (color) {


### PR DESCRIPTION
I have added two new scope properties to allow the user to pass in color values (as HEX color codes) for both `dark-color` and `light-color`.
The colors with default to white and black unless the user passes them in explicitly.